### PR TITLE
依存するライブラリのバージョンを確認するpluginの導入

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+dependencyUpdates.gradleReleaseChannel = "current"
+
 test {
 	useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
-	id "com.gorylenko.gradle-git-properties" version "2.3.1"
 	id 'org.springframework.boot' version '2.5.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id 'com.gorylenko.gradle-git-properties' version '2.3.1'
+	id 'com.github.ben-manes.versions' version '0.39.0'
 	id 'java'
 }
 
@@ -15,7 +16,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation group: 'io.sentry', name: 'sentry-spring-boot-starter', version: '5.0.1'
+	implementation 'io.sentry:sentry-spring-boot-starter:5.0.1'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.5.0'
+	id 'org.springframework.boot' version '2.5.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'com.gorylenko.gradle-git-properties' version '2.3.1'
 	id 'com.github.ben-manes.versions' version '0.39.0'


### PR DESCRIPTION
依存するライブラリのバージョンを確認するpluginの導入
[ben-manes/gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugin)

2021/06/12時点で最新のバージョンが2021/05/27なので開発がアクティブ
CIと組み合わせるとよさそう